### PR TITLE
feat: 예약 시간 입력 기능 추가 및 30분 단위 제한 로직 적용

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { handleTimeInputChange } from "@/utils/reservation/handleTimeInputChange";
+import { useState } from "react";
 
 interface Props {
   userInfo: any;
@@ -34,6 +35,7 @@ export default function ReservationContent({
   handleAddIcon,
   handleDeleteProgress,
 }: Props) {
+  const [timeError, setTimeError] = useState("");
   return (
     <div className="flex gap-6 items-start">
       <div className="flex gap-3">
@@ -60,9 +62,13 @@ export default function ReservationContent({
               maxLength={5}
               value={userInfo?.formattedStartTime || ""}
               placeholder="--:--"
-              readOnly={event?.mode === "add"}
               onChange={(e) =>
-                handleTimeInputChange(e.target.value, "start", setUserInfo)
+                handleTimeInputChange(
+                  e.target.value,
+                  "start",
+                  setUserInfo,
+                  setTimeError
+                )
               }
             />
             <div className="font-light p-2 min-h-7">~</div>
@@ -72,12 +78,19 @@ export default function ReservationContent({
               maxLength={5}
               value={userInfo?.formattedEndTime || ""}
               placeholder="--:--"
-              readOnly={event?.mode === "add"}
               onChange={(e) =>
-                handleTimeInputChange(e.target.value, "end", setUserInfo)
+                handleTimeInputChange(
+                  e.target.value,
+                  "end",
+                  setUserInfo,
+                  setTimeError
+                )
               }
             />
           </div>
+          {timeError && (
+            <div className="text-red-500 text-sm mt-1">{timeError}</div>
+          )}
 
           <div className="text-left m-1 font-semibold">성함</div>
           <input

--- a/src/utils/reservation/handleTimeInputChange.ts
+++ b/src/utils/reservation/handleTimeInputChange.ts
@@ -1,31 +1,31 @@
-import { timeMapping } from "./timeMapping";
-
-export const handleTimeInputChange = (
-  input: string,
+export function handleTimeInputChange(
+  inputValue: string,
   type: "start" | "end",
-  setUserInfo: React.Dispatch<React.SetStateAction<any>>
-) => {
-  const numericOnly = input.replace(/[^0-9]/g, "").slice(0, 4);
-  let formattedTime = "";
+  setUserInfo: (updater: (prev: any) => any) => void,
+  setTimeError: (msg: string) => void
+) {
+  setUserInfo((prev) => ({
+    ...prev,
+    [`formatted${type === "start" ? "Start" : "End"}Time`]: inputValue,
+  }));
 
-  if (numericOnly.length === 0) {
-    formattedTime = "";
-  } else if (numericOnly.length <= 2) {
-    formattedTime = numericOnly;
-  } else {
-    formattedTime = `${numericOnly.slice(0, 2)}:${numericOnly.slice(2)}`;
+  if (inputValue === "") {
+    setTimeError("");
+    return;
   }
 
-  const isValidTimeFormat =
-    formattedTime.length === 5 && formattedTime.includes(":");
+  const isValidFormat = /^\d{2}:\d{2}$/.test(inputValue);
+  if (!isValidFormat) {
+    setTimeError("시간은 HH:MM 형식으로 입력해주세요");
+    return;
+  }
 
-  setUserInfo((prev: any) => ({
-    ...prev,
-    [type === "start" ? "formattedStartTime" : "formattedEndTime"]:
-      formattedTime,
-    ...(isValidTimeFormat && {
-      [type === "start" ? "startIndex" : "endIndex"]:
-        timeMapping[formattedTime] ?? "",
-    }),
-  }));
-};
+  const [hh, mm] = inputValue.split(":").map(Number);
+
+  if (hh < 0 || hh > 23 || (mm !== 0 && mm !== 30)) {
+    setTimeError("시간은 30분 단위로만 입력 가능합니다");
+    return;
+  }
+
+  setTimeError("");
+}


### PR DESCRIPTION
## ✨ 주요 변경 사항

### 1. 예약 시간 직접 입력 가능하도록 수정 (30분 단위 제한)
- 기존에는 예약 추가 모달에서 시간 입력이 불가능했으나, 직접 입력할 수 있도록 개선
- 시간은 "HH:MM" 형식만 허용하며, 분은 00 또는 30만 입력 가능
- 잘못된 형식 또는 30분 단위가 아닐 경우 에러 메시지를 하단에 표시

### 2. 회원 메모 입력 UI 개선
- 메모 입력 전에는 회색 배경 + 회색 테두리
- 메모 입력 시 연두색 배경 + 초록 테두리로 변경되어 상태 시각화

### 3. 진도표 UI 추가 (읽기 전용)
- 고정 크기(320x192px)의 스크롤 영역 구성
- 향후 진도 데이터 연동을 위한 구조만 우선 구성

---

## 🛠 작업 방식

- `ReservationContent.tsx`에서 시간 입력 필드와 메모, 진도표 영역을 구조적으로 분리
- `handleTimeInputChange()` 유틸 함수를 사용하여 시간 입력값의 유효성을 체크하고 상태 반영
  - `userInfo.formattedStartTime` / `formattedEndTime`에 입력값 실시간 저장
  - 잘못된 형식일 경우 `setTimeError()`로 에러 메시지 출력
- `userInfo.memo`에 따라 메모 입력 UI 색상 조건부 처리
- 진도표는 추후 확장을 위해 비어있는 영역을 읽기 전용으로 구성함

---

## 📸 UI 스크린샷
https://github.com/user-attachments/assets/5b22bc44-6e32-420e-88d9-ffa02c94a1ae


## ❗ 기타 참고 사항
- 