### PR TITLE
fix: 지각/결석 레이아웃 깨짐 현상 수정

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -147,13 +147,60 @@ export default function ReservationContent({
           <div className="font-light bg-[#F2F8ED] p-2 rounded-lg border-[#B4D89C] border-2 text-[#3C6229] min-h-7">
             {userInfo?.planName || ""}
           </div>
+          {event?.mode === "edit" && (
+            <div>
+              <div className="text-left m-1 font-semibold">지각/결석</div>
+              <div className="flex flex-row">
+                <Image
+                  src={
+                    userInfo?.attendanceStatus === "LATE"
+                      ? "/reservationModal/checked.png"
+                      : "/reservationModal/unchecked.png"
+                  }
+                  alt="late"
+                  width={100}
+                  height={100}
+                  className="flex self-center size-5"
+                  onClick={() =>
+                    setUserInfo((prev: any) => ({
+                      ...prev,
+                      attendanceStatus:
+                        prev.attendanceStatus === "LATE" ? "NORMAL" : "LATE",
+                    }))
+                  }
+                />
+                <div className="flex-1 font-light p-2 min-h-7">지각</div>
+                <Image
+                  src={
+                    userInfo?.attendanceStatus === "ABSENT"
+                      ? "/reservationModal/checked.png"
+                      : "/reservationModal/unchecked.png"
+                  }
+                  alt="absent"
+                  width={100}
+                  height={100}
+                  className="flex self-center size-5"
+                  onClick={() =>
+                    setUserInfo((prev: any) => ({
+                      ...prev,
+                      attendanceStatus:
+                        prev.attendanceStatus === "ABSENT"
+                          ? "NORMAL"
+                          : "ABSENT",
+                    }))
+                  }
+                />
+                <div className="flex-1 font-light p-2 min-h-7">결석</div>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col gap-4 w-[320px]">
           <div className="w-[320px]">
             <div className="text-left m-1 font-semibold">회원 메모</div>
             <textarea
-              className={`w-full h-[100px] rounded-lg p-[8px_12px] resize-none transition-colors
+              className={`mt-2 w-full h-[100px] rounded-lg p-[8px_12px] resize-none transition-colors
         ${
           userInfo?.memo
             ? "bg-[#F2F8ED] border border-[#B4D89C] text-[#3C6229]"
@@ -168,57 +215,11 @@ export default function ReservationContent({
           <div>
             <div className="text-left m-1 font-semibold">진도표</div>
             <div
-              className="w-[320px] h-[192px] rounded-lg border border-[#D1D1D1] bg-white p-[8px_12px] text-gray-700 text-sm leading-relaxed overflow-y-auto select-none"
+              className="mt-2 w-[320px] h-[192px] rounded-lg border border-[#D1D1D1] bg-white p-[8px_12px] text-gray-700 text-sm leading-relaxed overflow-y-auto select-none"
               aria-hidden="true"
             ></div>
           </div>
         </div>
-
-        {event?.mode === "edit" && (
-          <div>
-            <div className="text-left m-1 font-semibold">지각/결석</div>
-            <div className="flex flex-row">
-              <Image
-                src={
-                  userInfo?.attendanceStatus === "LATE"
-                    ? "/reservationModal/checked.png"
-                    : "/reservationModal/unchecked.png"
-                }
-                alt="late"
-                width={100}
-                height={100}
-                className="flex self-center size-5"
-                onClick={() =>
-                  setUserInfo((prev: any) => ({
-                    ...prev,
-                    attendanceStatus:
-                      prev.attendanceStatus === "LATE" ? "NORMAL" : "LATE",
-                  }))
-                }
-              />
-              <div className="flex-1 font-light p-2 min-h-7">지각</div>
-              <Image
-                src={
-                  userInfo?.attendanceStatus === "ABSENT"
-                    ? "/reservationModal/checked.png"
-                    : "/reservationModal/unchecked.png"
-                }
-                alt="absent"
-                width={100}
-                height={100}
-                className="flex self-center size-5"
-                onClick={() =>
-                  setUserInfo((prev: any) => ({
-                    ...prev,
-                    attendanceStatus:
-                      prev.attendanceStatus === "ABSENT" ? "NORMAL" : "ABSENT",
-                  }))
-                }
-              />
-              <div className="flex-1 font-light p-2 min-h-7">결석</div>
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION


✨ 주요 변경 사항
1. 입력 필드 간 여백 정리
- 예약 시간 입력 필드 아래 여백(8px) 기준으로
→ 회원 메모와 진도표 인풋 위에도 동일한 여백(mt-2)을 적용하여 시각적 정렬을 개선함

2. 지각/결석 토글 UI 위치 수정
- 지각/결석 상태 토글 UI의 위치를 재배치하여 레이아웃을 정돈
- 사용자 정보 입력 영역의 흐름에 맞게 자연스럽게 배치되도록 구조 조정

🛠 작업 방식
- Tailwind 클래스 기준으로 모든 인풋 위 margin-top을 mt-2로 통일
- 기존에 위치가 어색했던 지각/결석 UI를 사용자 정보 섹션 내부에서 일관된 간격과 정렬로 재배치

📸 UI 스크린샷
<img width="656" alt="스크린샷 2025-05-23 오후 9 42 46" src="https://github.com/user-attachments/assets/2cb91702-7899-4961-8851-6e30d0489a5f" />