### PR TITLE
feat: 예약 수정 API 연동

### DIFF
--- a/src/api/reservation/putUpdateReservations.ts
+++ b/src/api/reservation/putUpdateReservations.ts
@@ -12,25 +12,21 @@ export const putUpdateReservations = async (data: {
   attendanceStatus: string;
   progressList: {
     progressId: number;
-    date: string;
     content: string;
-    deleted: boolean;
-  };
+  }[];
 }) => {
-  console.log("data", data);
   try {
-    console.log(data);
     const response = await apiClient.put(
       "/api/reservation/updatedReservation",
       {
-        reservationId: data?.reservationId,
-        reservationDate: data?.reservationDate,
-        startIndex: data?.startIndex,
-        endIndex: data?.endIndex,
-        memo: data?.memo,
-        seatNumber: data?.seatNumber,
-        attendanceStatus: data?.attendanceStatus,
-        progressList: data?.progressList,
+        reservationId: data.reservationId,
+        reservationDate: data.reservationDate,
+        startIndex: data.startIndex,
+        endIndex: data.endIndex,
+        memo: data.memo,
+        seatNumber: data.seatNumber,
+        attendanceStatus: data.attendanceStatus,
+        progressList: data.progressList,
       }
     );
     if (response.status === 200) {

--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { handleTimeInputChange } from "@/utils/reservation/handleTimeInputChange";
+import { putUpdateReservations } from "@/api/reservation/putUpdateReservations";
 import { useState } from "react";
 
 interface Props {

--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -52,6 +52,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
         if (data?.data) {
           setUserInfo({
             ...data.data,
+            seatNumber: data.data.seatNumber ?? event.seatNumber,
             progressList: Array.isArray(data.data.progressList)
               ? data.data.progressList
               : data.data.progressList
@@ -87,28 +88,37 @@ const SelectedEventModal: React.FC<EventProps> = ({
       setTimeout(async () => {
         await refreshCalendar();
       }, 1000);
-      
+
       onClose();
       return response;
     }
   };
 
   const handleEditSubmit = async () => {
-    if (event?.mode == "edit") {
-      const response = await putUpdateReservations({
-        reservationId: Number(event?.reservationId),
-        reservationDate: userInfo?.reservationDate,
-        startIndex: userInfo?.startIndex,
-        endIndex: userInfo?.endIndex,
-        memo: userInfo?.memo,
-        seatNumber: event?.seatNumber,
-        attendanceStatus: userInfo?.attendanceStatus || "NORMAL",
-        progressList: userInfo?.progressList || [],
-      });
+    if (event?.mode === "edit") {
+      try {
+        const response = await putUpdateReservations({
+          reservationId: Number(event.reservationId),
+          reservationDate: userInfo?.reservationDate,
+          startIndex: userInfo?.startIndex,
+          endIndex: userInfo?.endIndex,
+          memo: userInfo?.memo,
+          seatNumber: userInfo.seatNumber,
+          attendanceStatus: userInfo?.attendanceStatus || "NORMAL",
+          progressList: (userInfo?.progressList || []).map((p: any) => ({
+            progressId: p.progressId,
+            content: p.content,
+          })),
+        });
 
-      await refreshCalendar();
-      onClose();
-      return response;
+        console.log("✅ API 응답:", response);
+
+        await refreshCalendar();
+        onClose();
+      } catch (err) {
+        console.error("❌ API 호출 에러:", err);
+        alert("예약 수정에 실패했습니다.");
+      }
     }
   };
 

--- a/src/utils/reservation/handleTimeInputChange.ts
+++ b/src/utils/reservation/handleTimeInputChange.ts
@@ -7,6 +7,7 @@ export function handleTimeInputChange(
   setUserInfo((prev) => ({
     ...prev,
     [`formatted${type === "start" ? "Start" : "End"}Time`]: inputValue,
+    seatNumber: prev.seatNumber,
   }));
 
   if (inputValue === "") {


### PR DESCRIPTION
✨ 주요 변경 사항
1. 예약 수정 기능 API 연동
- 예약 수정 시 seatNumber, startIndex, endIndex, memo, attendanceStatus, progressList 등의 정보를 포함하여 서버에 전달되도록 구현
- 기존에는 좌석 번호 누락으로 인해 400 에러 발생했으나, 이를 해결하기 위해 seatNumber 값을 SelectedEventModal.tsx에서 명확히 설정하도록 수정
- 수정 완료 후 캘린더 새로고침 및 모달 닫힘 처리 추가

🛠 작업 방식
- SelectedEventModal.tsx 내 handleEditSubmit() 함수에서 putUpdateReservations() API를 호출하도록 설정

- 좌석 번호(seatNumber)가 userInfo에 항상 포함되도록 getReservationCustomerDetails() 호출 결과에 따라 병합 처리

- progressList는 API에서 요구하는 구조에 맞춰 map()을 통해 progressId와 content만 추출하여 전달

- API 호출이 성공(200)일 경우 loadReservation()을 다시 호출하여 캘린더 데이터를 최신화하고, 모달을 닫도록 처리

📸 UI 스크린샷
<img width="642" alt="스크린샷 2025-05-24 오후 4 27 07" src="https://github.com/user-attachments/assets/1976a098-293d-450e-9540-831ba8ee7a43" />
<img width="625" alt="스크린샷 2025-05-24 오후 4 27 27" src="https://github.com/user-attachments/assets/a27a99c0-af50-47e3-82a1-a8f43248f574" />


❗ 기타 참고 사항