### PR TITLE
fix: 예약 관련 input 스타일 수정

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -58,7 +58,7 @@ export default function ReservationContent({
           </div>
           <div className="flex flex-row gap-1">
             <input
-              className="flex-1 font-light bg-[#F6F6F6] border-[#D1D1D1] border-2 p-2 rounded-lg text-[#888888] min-h-7 min-w-0"
+              className="flex-1 font-light bg-[#F2F8ED] border border-[#B4D89C] p-[8px_12px] rounded-lg text-[#3C6229] min-h-7 min-w-0"
               type="text"
               maxLength={5}
               value={userInfo?.formattedStartTime || ""}
@@ -74,7 +74,7 @@ export default function ReservationContent({
             />
             <div className="font-light p-2 min-h-7">~</div>
             <input
-              className="flex-1 font-light bg-[#F6F6F6] border-[#D1D1D1] border-2 p-2 rounded-lg text-[#888888] min-h-7 min-w-0"
+              className="flex-1 font-light bg-[#F2F8ED] border border-[#B4D89C] p-[8px_12px] rounded-lg text-[#3C6229] min-h-7 min-w-0"
               type="text"
               maxLength={5}
               value={userInfo?.formattedEndTime || ""}
@@ -95,7 +95,7 @@ export default function ReservationContent({
 
           <div className="text-left m-1 font-semibold">성함</div>
           <input
-            className="flex-1 font-light bg-[#F2F8ED] p-2 rounded-lg border-[#B4D89C] border-2 text-[#3C6229] min-h-7"
+            className="flex-1 font-light bg-[#F2F8ED] p-[8px_12px] rounded-lg border border-[#B4D89C] text-[#3C6229] min-h-7"
             type="search"
             value={event?.mode === "add" ? searchKeyword : userInfo?.name}
             onChange={(e) => handleSearch(e.target.value)}
@@ -119,7 +119,7 @@ export default function ReservationContent({
 
           <div className="text-left m-1 font-semibold">전화번호</div>
           <input
-            className="flex-1 font-light bg-[#F2F8ED] p-2 rounded-lg border-[#B4D89C] border-2 text-[#3C6229] min-h-7"
+            className="flex-1 font-light bg-[#F6F6F6] border border-[#D1D1D1] p-[8px_12px] rounded-lg text-[#888888] min-h-7"
             value={userInfo?.phone || ""}
             type="tel"
             onChange={(e) => handleInputChange("phone", e.target.value)}
@@ -135,17 +135,17 @@ export default function ReservationContent({
               </div>
             </div>
             <div className="flex flex-row gap-1">
-              <div className="flex-1 font-light bg-[#F6F6F6] border-[#D1D1D1] border-2 p-2 rounded-lg text-[#888888] min-h-7 min-w-0">
+              <div className="flex-1 font-light bg-[#F6F6F6] border border-[#D1D1D1] p-[8px_12px] rounded-lg text-[#888888] min-h-7 min-w-0">
                 {userInfo?.endDate?.split("T")[0] || ""}
               </div>
-              <div className="flex-1 font-light bg-[#F6F6F6] border-[#D1D1D1] border-2 p-2 rounded-lg text-[#888888] min-h-7 min-w-0">
+              <div className="flex-1 font-light bg-[#F6F6F6] border border-[#D1D1D1] p-[8px_12px] rounded-lg text-[#888888] min-h-7 min-w-0">
                 {userInfo?.remainingTime || ""}
               </div>
             </div>
           </div>
 
           <div className="text-left m-1 font-semibold">이용권</div>
-          <div className="font-light bg-[#F2F8ED] p-2 rounded-lg border-[#B4D89C] border-2 text-[#3C6229] min-h-7">
+          <div className="font-light bg-[#F6F6F6] p-[8px_12px] rounded-lg border border-[#D1D1D1] text-[#888888] min-h-7">
             {userInfo?.planName || ""}
           </div>
           {event?.mode === "edit" && (


### PR DESCRIPTION
## ✨ 주요 변경 사항

### 1. 예약 시간 입력 UI 스타일 수정
예약 시간 입력 필드의 border 두께(1px), padding(8px 12px)을 회원 메모와 통일

### 2. 성함 입력 UI 스타일 수정
기존 border-2 → border, p-2 → p-[8px_12px]로 수정하여 회원 메모와 동일한 스타일로 통일

### 3. 회색 영역 인풋 스타일 정리
전화번호, 이벤트 종료 기간, 남은 기간, 이용권 필드를 회색 스타일로 통일
---

## 🛠 작업 방식
- ReservationContent.tsx 내 입력 필드별 클래스를 통일성
- 회색 스타일은 bg-[#F6F6F6] border border-[#D1D1D1] text-[#888888] p-[8px_12px] 고정 사용
- 초록색 스타일은 bg-[#F2F8ED] border border-[#B4D89C] text-[#3C6229] p-[8px_12px]로 통일
- 입력 요소의 시각적 레이아웃 정렬과 두께 통일을 조정함
---

## 📸 UI 스크린샷
<img width="621" alt="스크린샷 2025-06-01 오후 1 39 51" src="https://github.com/user-attachments/assets/a5084ade-d932-4845-8891-6f16c96bee28" />


## ❗ 기타 참고 사항
- 