### PR TITLE
fix: 진도표 추가 팝업 기본 숨김 상태로 변경

### DIFF
--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -131,7 +131,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
     }
   };
 
-  const [showProgressModal, setShowProgressModal] = useState(true);
+  const [showProgressModal, setShowProgressModal] = useState(false);
   const [progressContent, setProgressContent] = useState("");
   const currentDate = new Date().toISOString().split("T")[0];
 


### PR DESCRIPTION
## ✨ 주요 변경 사항
### 1. 진도표 추가 팝업 기본 숨김 처리
기존에는 SelectedEventModal 렌더링 시 진도표 추가 팝업이 자동으로 열리는 상태였음
초기 상태값을 false로 설정하여 기본적으로 팝업이 보이지 않도록 수정
이후에는 사용자 조작(+ 버튼 등)을 통해 setShowProgressModal(true) 호출 시에만 팝업이 열리도록 변경

## 🛠 작업 방식
### SelectedEventModal.tsx 내부 showProgressModal의 초기값을 true → false로 변경

const [showProgressModal, setShowProgressModal] = useState(false);
기존 팝업 렌더링 조건은 유지하고, 사용자가 handleAddIcon() 등을 통해 명시적으로 열도록 흐름 수정
기본 렌더링 시 모달이 뜨는 혼란을 방지하고, UI 동작 흐름을 명확히 정리함

## 📸 UI 스크린샷
<img width="1155" alt="스크린샷 2025-06-01 오후 2 06 10" src="https://github.com/user-attachments/assets/30253a12-044f-4e80-b8cc-3f18ada50320" />

## ❗ 기타 참고 사항
추후 진도표 리스트 항목 클릭 시에도 팝업이 열리는 기능으로 확장 가능
초기 진입 시에는 모든 팝업이 닫힌 상태로 진입하도록 흐름 통일

