### PR TITLE
feat: 진도표 리스트 구현, 클릭 시 수정 팝업 열기 및 내용 수정 api 연동

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -15,6 +15,7 @@ interface Props {
   handleSelectCustomer: (customer: any) => void;
   handleInputChange: (field: string, value: string) => void;
   handleAddIcon: () => void;
+  handleEditProgress: (progress: any) => void;
   handleDeleteProgress: (progress: {
     progressId?: number;
     date: string;
@@ -27,16 +28,15 @@ export default function ReservationContent({
   setUserInfo,
   event,
   searchKeyword,
-  setSearchKeyword,
   isSearching,
   customerList,
   handleSearch,
   handleSelectCustomer,
   handleInputChange,
-  handleAddIcon,
-  handleDeleteProgress,
+  handleEditProgress,
 }: Props) {
   const [timeError, setTimeError] = useState("");
+
   return (
     <div className="flex gap-6 items-start">
       <div className="flex gap-3">
@@ -215,10 +215,42 @@ export default function ReservationContent({
 
           <div>
             <div className="text-left m-1 font-semibold">진도표</div>
-            <div
-              className="mt-2 w-[320px] h-[192px] rounded-lg border border-[#D1D1D1] bg-white p-[8px_12px] text-gray-700 text-sm leading-relaxed overflow-y-auto select-none"
-              aria-hidden="true"
-            ></div>
+            <div className="mt-2 w-[320px] h-[251px] rounded-lg border border-[#D1D1D1] bg-white px-2 py-2 overflow-y-auto">
+              {userInfo?.progressList?.filter((p: any) => !p.deleted).length >
+              0 ? (
+                userInfo.progressList
+                  .filter((p: any) => !p.deleted)
+                  .map((p: any) => (
+                    <div
+                      key={`${p.progressId}-${p.date}`}
+                      className="w-full h-[53px] mb-2 px-[10px] py-[8px] border border-[#D1D1D1] rounded-lg flex justify-between items-start"
+                      onClick={() => handleEditProgress(p)}
+                    >
+                      <div className="flex flex-col justify-start">
+                        <div className="text-[#888888] font-semibold text-[12px] leading-[120%] mb-[4px]">
+                          {new Date(p.date).toLocaleDateString("ko-KR", {
+                            year: "numeric",
+                            month: "2-digit",
+                            day: "2-digit",
+                            weekday: "short",
+                          })}
+                        </div>
+                        <div className="text-[14px] text-black leading-[130%]">
+                          {p.content || "내용 없음"}
+                        </div>
+                      </div>
+
+                      {p.usedTime && (
+                        <div className="text-black text-[14px] font-normal font-['Inter'] leading-[120%]">
+                          {(p.usedTime * 10).toString().replace(/\.0$/, "")}H
+                        </div>
+                      )}
+                    </div>
+                  ))
+              ) : (
+                <div className="text-gray-400">진도 내역이 없습니다.</div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -41,12 +41,11 @@ const SelectedEventModal: React.FC<EventProps> = ({
   calendarInstance,
 }) => {
   const [userInfo, setUserInfo] = useState<any>(null);
+  const [editProgress, setEditProgress] = useState<any>(null);
+  const [progressUsedTime, setProgressUsedTime] = useState(""); // 시간 입력 상태
 
-  // mode case
   useEffect(() => {
-    if (event?.mode == "add") {
-      setUserInfo({ ...event, progressList: [] });
-    } else if (event?.mode == "edit") {
+    if (event?.mode === "edit") {
       const fetchUserInfo = async () => {
         const data = await getReservationCustomerDetails(event.reservationId);
         if (data?.data) {
@@ -58,6 +57,9 @@ const SelectedEventModal: React.FC<EventProps> = ({
               : data.data.progressList
               ? [data.data.progressList]
               : [],
+            originalProgressList: JSON.parse(
+              JSON.stringify(data.data.progressList)
+            ), // 깊은 복사
           });
         }
       };
@@ -65,11 +67,41 @@ const SelectedEventModal: React.FC<EventProps> = ({
     }
   }, [event]);
 
+  const handleEditProgress = (progress: any) => {
+    setEditProgress(progress);
+    setProgressContent(progress.content);
+    setProgressUsedTime(progress.usedTime);
+    setShowProgressModal(true);
+  };
+
   const handleInputChange = (field: string, value: string) => {
     setUserInfo((prev: any) => ({
       ...prev,
       [field]: value,
     }));
+  };
+
+  const handleConfirmProgress = () => {
+    if (!progressContent.trim()) return;
+
+    if (editProgress) {
+      const updatedList = userInfo.progressList.map((item: any) =>
+        item.progressId === editProgress.progressId
+          ? {
+              ...item,
+              content: progressContent,
+              usedTime: Number(progressUsedTime),
+            }
+          : item
+      );
+      setUserInfo({ ...userInfo, progressList: updatedList });
+    }
+
+    // 초기화
+    setShowProgressModal(false);
+    setEditProgress(null);
+    setProgressContent("");
+    setProgressUsedTime("");
   };
 
   const refreshCalendar = async () => {
@@ -97,26 +129,42 @@ const SelectedEventModal: React.FC<EventProps> = ({
   const handleEditSubmit = async () => {
     if (event?.mode === "edit") {
       try {
+        const originalProgressList = userInfo.originalProgressList || [];
+
+        const updatedProgressList = userInfo.progressList || [];
+
+        const modifiedProgressList = updatedProgressList.filter(
+          (updated: any) => {
+            const original = originalProgressList.find(
+              (orig: any) => orig.progressId === updated.progressId
+            );
+            return (
+              original &&
+              (original.content !== updated.content ||
+                original.usedTime !== updated.usedTime)
+            );
+          }
+        );
+
         const response = await putUpdateReservations({
           reservationId: Number(event.reservationId),
           reservationDate: userInfo?.reservationDate,
           startIndex: userInfo?.startIndex,
           endIndex: userInfo?.endIndex,
           memo: userInfo?.memo,
-          seatNumber: userInfo.seatNumber,
+          seatNumber: userInfo?.seatNumber,
           attendanceStatus: userInfo?.attendanceStatus || "NORMAL",
-          progressList: (userInfo?.progressList || []).map((p: any) => ({
+          progressList: modifiedProgressList.map((p: any) => ({
             progressId: p.progressId,
             content: p.content,
           })),
         });
 
-        console.log("✅ API 응답:", response);
-
+        console.log("✅ 예약 및 진도 수정 완료", response);
         await refreshCalendar();
         onClose();
       } catch (err) {
-        console.error("❌ API 호출 에러:", err);
+        console.error("❌ 예약 수정 실패", err);
         alert("예약 수정에 실패했습니다.");
       }
     }
@@ -247,7 +295,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
         {showProgressModal && (
           <div className="absolute right-[-410px] bottom-0 z-50 w-[400px] bg-white shadow-lg rounded-lg p-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">진도표 추가</h2>
+              <h2 className="text-xl font-semibold">진도표 수정</h2>
               <Button
                 className="size-12"
                 onClick={() => setShowProgressModal(false)}
@@ -280,7 +328,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
               <BasicButton
                 color="primary"
                 className="w-full"
-                onClick={handleAddProgress}
+                onClick={handleConfirmProgress}
               >
                 확인
               </BasicButton>
@@ -304,6 +352,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
             handleInputChange={handleInputChange}
             handleAddIcon={handleAddIcon}
             handleDeleteProgress={handleDeleteProgress}
+            handleEditProgress={handleEditProgress}
           />
         )}
         {/* ReservationFooter */}


### PR DESCRIPTION
<h2 data-start="141" data-end="154">✨ 주요 변경 사항</h2>
<h3 data-start="156" data-end="181">1. 진도표 추가 팝업 기본 숨김 처리</h3>
<ul data-start="182" data-end="328">
<li data-start="182" data-end="240">
<p data-start="184" data-end="240"><code data-start="184" data-end="204">SelectedEventModal</code> 진입 시 자동으로 뜨던 진도표 추가 모달을 기본적으로 숨김 처리</p>
</li>
<li data-start="241" data-end="288">
<p data-start="243" data-end="288"><code data-start="243" data-end="262">showProgressModal</code> 초기값을 <code data-start="268" data-end="274">true</code> → <code data-start="277" data-end="284">false</code>로 수정</p>
</li>
<li data-start="289" data-end="328">
<p data-start="291" data-end="328"><code data-start="291" data-end="294">+</code> 버튼 또는 진도 리스트 클릭 시 명시적으로 열도록 흐름 정리</p>
</li>
</ul>
<h3 data-start="330" data-end="366">2. 진도표 리스트 클릭 시 수정 모달 열리도록 기능 구현</h3>
<ul data-start="367" data-end="493">
<li data-start="367" data-end="414">
<p data-start="369" data-end="414">진도표 리스트 항목을 클릭하면 해당 항목 내용이 수정 모달에 자동 입력되도록 구현</p>
</li>
<li data-start="415" data-end="493">
<p data-start="417" data-end="493"><code data-start="417" data-end="431">editProgress</code>, <code data-start="433" data-end="450">progressContent</code>, <code data-start="452" data-end="470">progressUsedTime</code> 상태를 새로 정의하여 클릭 시 정보 주입</p>
</li>
</ul>
<h3 data-start="495" data-end="524">3. 수정된 진도 항목만 반영되도록 구조 설계</h3>
<ul data-start="525" data-end="638">
<li data-start="525" data-end="571">
<p data-start="527" data-end="571">모달에서 수정 후 “확인”을 누르면 화면상의 진도 리스트에 변경 내용 즉시 반영</p>
</li>
<li data-start="572" data-end="638">
<p data-start="574" data-end="638">실제 API 호출은 최종 “수정 완료” 버튼 클릭 시 수행하며, <code data-start="610" data-end="624">progressList</code>에는 수정된 항목만 포함됨</p>
</li>
</ul>
<hr data-start="640" data-end="643">
<h2 data-start="645" data-end="656">🛠 작업 방식</h2>
<ul data-start="658" data-end="919">
<li data-start="658" data-end="717">
<p data-start="660" data-end="717"><code data-start="660" data-end="684">SelectedEventModal.tsx</code>에서 <code data-start="687" data-end="704">useState(false)</code>로 팝업 초기 상태 설정</p>
</li>
<li data-start="718" data-end="791">
<p data-start="720" data-end="791">진도 리스트 각 항목에 <code data-start="733" data-end="763">onClick={handleEditProgress}</code> 이벤트 추가하여 클릭 시 수정 모달 열리도록 구성</p>
</li>
<li data-start="792" data-end="846">
<p data-start="794" data-end="846"><code data-start="794" data-end="817">handleConfirmProgress</code> 함수에서 변경된 값만 리스트에 반영하고 상태 초기화</p>
</li>
<li data-start="847" data-end="919">
<p data-start="849" data-end="919">최종 수정 API (<code data-start="860" data-end="883">putUpdateReservations</code>)는 수정된 진도표 리스트만 추출하여 서버에 전달되도록 로직 구현</p>
</li>
</ul>
<hr data-start="921" data-end="924">
<h2 data-start="926" data-end="939">📸 UI 스크린샷</h2>



https://github.com/user-attachments/assets/15897776-118c-4f97-8f34-1a2c2f2818fc


<div class="sticky end-(--thread-content-margin) h-0 self-end select-none"><div class="absolute end-0 flex items-end"><span class="" data-state="closed"><button class="bg-token-bg-primary hover:bg-token-bg-tertiary text-token-text-secondary my-1 rounded-sm p-1 transition-opacity group-[:not(:hover):not(:focus-within)]:pointer-events-none group-[:not(:hover):not(:focus-within)]:opacity-0"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon-md-heavy"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 5C7 3.34315 8.34315 2 10 2H19C20.6569 2 22 3.34315 22 5V14C22 15.6569 20.6569 17 19 17H17V19C17 20.6569 15.6569 22 14 22H5C3.34315 22 2 20.6569 2 19V10C2 8.34315 3.34315 7 5 7H7V5ZM9 7H14C15.6569 7 17 8.34315 17 10V15H19C19.5523 15 20 14.5523 20 14V5C20 4.44772 19.5523 4 19 4H10C9.44772 4 9 4.44772 9 5V7ZM5 9C4.44772 9 4 9.44772 4 10V19C4 19.5523 4.44772 20 5 20H14C14.5523 20 15 19.5523 15 19V10C15 9.44772 14.5523 9 14 9H5Z" fill="currentColor"></path></svg></button></span></div></div></div></div>
<hr data-start="1097" data-end="1100">
<h2 data-start="1102" data-end="1115">❗ 기타 참고 사항</h2>
<ul data-start="1117" data-end="1278">
<li data-start="1117" data-end="1143">
<p data-start="1119" data-end="1143">진도표 삭제 기능은 별도 PR에서 다룰 예정</p>
</li>
<li data-start="1144" data-end="1184">
<p data-start="1146" data-end="1184">향후 모달 내 validation 처리(빈 입력 방지 등) 보완 예정</p>
</li>
<li data-start="1185" data-end="1246">
<p data-start="1187" data-end="1246">API 연동 시 <code data-start="1196" data-end="1210">progressList</code>에는 <code data-start="1213" data-end="1225">progressId</code>와 <code data-start="1227" data-end="1236">content</code>만 포함되어 전송됨</p>
</li>
<li data-start="1247" data-end="1278">
<p data-start="1249" data-end="1278">이 변경 사항은 예약 편집 기능의 UX를 크게 개선함</p>
</li>
</ul>
