### PR TITLE
fix: 예약 추가 모달 깨지는 현상 수정

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -215,7 +215,11 @@ export default function ReservationContent({
 
           <div>
             <div className="text-left m-1 font-semibold">진도표</div>
-            <div className="mt-2 w-[320px] h-[251px] rounded-lg border border-[#D1D1D1] bg-white px-2 py-2 overflow-y-auto">
+            <div
+              className={`mt-2 w-[320px] rounded-lg border border-[#D1D1D1] bg-white px-2 py-2 overflow-y-auto ${
+                event?.mode === "edit" ? "h-[251px]" : "min-h-[180px]"
+              }`}
+            >
               {userInfo?.progressList?.filter((p: any) => !p.deleted).length >
               0 ? (
                 userInfo.progressList
@@ -223,7 +227,8 @@ export default function ReservationContent({
                   .map((p: any) => (
                     <div
                       key={`${p.progressId}-${p.date}`}
-                      className="w-full h-[53px] mb-2 px-[10px] py-[8px] border border-[#D1D1D1] rounded-lg flex justify-between items-start"
+                      className="w-full h-[53px] mb-2 px-[10px] py-[8px] rounded-lg flex justify-between items-start
+             border border-[#D1D1D1] hover:border-[#B4D89C] hover:border-2 transition-all duration-150 cursor-pointer"
                       onClick={() => handleEditProgress(p)}
                     >
                       <div className="flex flex-col justify-start">

--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -45,7 +45,9 @@ const SelectedEventModal: React.FC<EventProps> = ({
   const [progressUsedTime, setProgressUsedTime] = useState(""); // 시간 입력 상태
 
   useEffect(() => {
-    if (event?.mode === "edit") {
+    if (event?.mode == "add") {
+      setUserInfo({ ...event, progressList: [] });
+    } else if (event?.mode === "edit") {
       const fetchUserInfo = async () => {
         const data = await getReservationCustomerDetails(event.reservationId);
         if (data?.data) {
@@ -59,7 +61,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
               : [],
             originalProgressList: JSON.parse(
               JSON.stringify(data.data.progressList)
-            ), // 깊은 복사
+            ),
           });
         }
       };


### PR DESCRIPTION
예약 추가 시 진도표 영역 레이아웃 깨지는 문제 수정

- 예약 추가 모드에서 진도표 내역이 없을 때 높이가 과하게 설정되던 문제 해결
- event.mode === 'add' 조건일 경우 진도표 영역에 min-height 적용
- event.mode === 'edit'일 경우 기존처럼 height 고정 (스크롤 유지)