### PR TITLE
fix: 사이드바 예약버튼 페이지 오류 해결

### DIFF
--- a/src/app/components/SideBar.tsx
+++ b/src/app/components/SideBar.tsx
@@ -18,7 +18,7 @@ function SideBar() {
     router.push("/members/");
   };
   const handleNavigateUserCalendar = () => {
-    router.push("/");
+    router.push("/reservation");
   };
   const handleNavigateReward = () => {
     router.push("/rewards/");


### PR DESCRIPTION
## ✨ 주요 변경 사항
기존에 reservation화면(달력) 으로 이동하기 위해 네비게이션바의 버튼을 누르면 일시적으로 로그인화면이 뜨고, 해당 페이지로 넘어가는 오류를 해결하였습니다.
---

## 🛠 작업 방식
```tsx
    router.push("/");
```
와 같이 적혀있던 루트를
```tsx
    router.push("/reservation");
```
으로 수정하였습니다.

기존에는 기본 화면인 ("/")을 띄운 후, calander정보를 api에서 모두 받아왔을 때만 캘린더를 띄우도록 하는 '조건부'로 동작이 되었습니다.
수정 이후에는, 우선 비어있는 캘린더로 이동한 후, api에서 정보를 받아오도록 기다리는 방식으로 수정하였습니다

---

## 📸 UI 스크린샷
### 1. 변경 전 화면

https://github.com/user-attachments/assets/0be9367b-bd6d-4f6f-8b6e-61965182fbb2

### 2. 변경 후 화면
https://github.com/user-attachments/assets/29c9930b-bd08-4f2a-a550-ee98f19b52dc




---

## ❗ 기타 참고 사항