### PR TITLE
feat/멤버 리스트 불러오기 전 로딩중 화면 추가

### DIFF
--- a/src/app/components/member/list/MemberList.tsx
+++ b/src/app/components/member/list/MemberList.tsx
@@ -3,18 +3,27 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import MemberRow from "./MemberRow";
 import { Member } from "@/types/memberType";
-import DetailMember from "../detail/DetailMember";
+// DetailMember 임포트는 MemberList에서 직접 모달을 띄우지 않는다면 필요 없습니다.
+// import DetailMember from "../detail/DetailMember";
 import useCustomerStore from "@/store/useCustomerStore";
 import usePaginatedMembers from "@/hooks/member/usePaginatedMembers";
 import MemberRowSkeleton from "./MemberRowSkeleton";
 import { option1Type } from "@/app/members/page";
+// MembersLoading 임포트도 MemberList에서 직접 렌더링하지 않는다면 필요 없습니다.
+// import MembersLoading from "@/app/members/MembersLoading";
 
-const MemberList = ({ selectedOption1 }: { selectedOption1: option1Type }) => {
+const MemberList = ({
+  selectedOption1,
+  setIsDataLoading,
+}: {
+  selectedOption1: option1Type;
+  setIsDataLoading: (isLoading: boolean) => void;
+}) => {
   const { fetchCustomer } = useCustomerStore();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedCustomerId, setSelectedCustomerId] = useState<number | null>(
-    null
-  );
+  // ⚠️ 모달 관련 상태는 page.tsx에서 관리하는 것이 더 좋습니다.
+  // const [isModalOpen, setIsModalOpen] = useState(false);
+  // const [selectedCustomerId, setSelectedCustomerId] = useState<number | null>(null);
+
   // ✅ React Query 무한스크롤 데이터 가져오기
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     usePaginatedMembers(selectedOption1);
@@ -22,6 +31,7 @@ const MemberList = ({ selectedOption1 }: { selectedOption1: option1Type }) => {
   // ✅ `data.pages`가 존재하는 경우 평탄화
   const members: Member[] =
     (data as any)?.pages?.flatMap((page: { data: any }) => page.data) || []; // ✅ pages에서 data만 추출
+
   // ✅ `fetchNextPage`를 `useCallback`으로 고정
   const loadMore = useCallback(() => {
     if (hasNextPage) {
@@ -47,51 +57,47 @@ const MemberList = ({ selectedOption1 }: { selectedOption1: option1Type }) => {
     return () => observer.disconnect();
   }, [loadMore]);
 
+  // ⚠️ `handleRowClick`은 `page.tsx`의 함수를 prop으로 받아 직접 호출하는 것이 좋습니다.
+  // MemberList는 목록 렌더링에만 집중하고, 클릭 이벤트 처리는 부모에게 위임하세요.
+  // 현재는 page.tsx에서 직접 onClick을 handleRowClick으로 연결하고 있으므로, 이 함수는 page.tsx의 handleRowClick을 직접 호출하게 됩니다.
   const handleRowClick = (customerId: number) => {
-    console.log("선택된 customerId:", customerId);
+    console.log("MemberList에서 클릭된 customerId:", customerId);
     fetchCustomer(customerId); // Zustand에서 API 호출
-    setSelectedCustomerId(customerId);
-    setIsModalOpen(true);
+    // ⚠️ 이 아래 두 줄은 page.tsx의 handleRowClick에서 처리됩니다.
+    // setSelectedCustomerId(customerId);
+    // setIsModalOpen(true);
   };
 
-  const closeModal = () => {
-    setIsModalOpen(false);
-    setSelectedCustomerId(null); // 모달 닫기 시 초기화
-  };
+  // ✅ React Query의 isLoading 상태를 부모 컴포넌트로 전달합니다.
+  useEffect(() => {
+    setIsDataLoading(isLoading);
+    console.log("MemberList 내부의 isLoading:", isLoading);
+  }, [isLoading, setIsDataLoading]);
 
   return (
-    <div className="grid grid-cols-1 rounded-xl gap-2 p-4 border border-gray-300  h-full overflow-y-auto">
-      {isLoading
+    <div className="grid grid-cols-1 rounded-xl gap-2 p-4 border border-gray-300 h-full overflow-y-auto">
+      {isLoading && members.length === 0
         ? Array.from({ length: 6 }).map((_, i) => <MemberRowSkeleton key={i} />)
         : members.map((member) => (
             <MemberRow
               key={member.customerId}
               member={member}
+              // `page.tsx`의 `handleRowClick`을 직접 사용하도록 합니다.
               onClick={() => handleRowClick(member.customerId)}
             />
           ))}
+
       {/* ✅ 무한스크롤 트리거 요소 (마지막 요소 감지) */}
       <div
         ref={observerRef}
         className="h-10 w-full flex justify-center items-center"
       >
-        {isFetchingNextPage && (
-          <span className="text-gray-500">로딩 중...</span>
+        {isFetchingNextPage && hasNextPage && (
+          <span className="text-gray-500">
+            더 많은 회원 정보를 불러오는 중...
+          </span>
         )}
       </div>
-      {/* 모달 */}
-      {isModalOpen && selectedCustomerId && (
-        <>
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div className="bg-white w-full max-w-4xl p-6 rounded-lg shadow-lg relative">
-              <DetailMember
-                customerId={selectedCustomerId}
-                onClose={closeModal}
-              />
-            </div>
-          </div>
-        </>
-      )}
     </div>
   );
 };

--- a/src/app/members/loading.tsx
+++ b/src/app/members/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <p>회원 정보를 로딩 중입니다...</p>
+    </div>
+  );
+}

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import SideBar from "../components/SideBar";
 import TopControls from "../components/member/list/TopControls";
 import MemberList from "../components/member/list/MemberList";
@@ -9,6 +9,7 @@ import useCustomerStore from "@/store/useCustomerStore";
 import DetailMember from "../components/member/detail/DetailMember";
 
 export type option1Type = "ACTIVE" | "DELETED" | "INACTIVE";
+
 export default function Page() {
   const [searchResults, setSearchResults] = useState<any[]>([]); // 검색 결과 상태
   const [filterOption1, setFilterOption1] = useState<option1Type>("ACTIVE");
@@ -17,6 +18,17 @@ export default function Page() {
     null
   );
   const [isModalOpen, setIsModalOpen] = useState(false);
+  // ✅ isDataLoading의 초기값을 true로 설정합니다.
+  // 이렇게 해야 처음 페이지가 로드될 때 로딩 화면이 먼저 보입니다.
+  const [isDataLoading, setIsDataLoading] = useState<boolean>(true);
+
+  // useRef로 최신 isDataLoading 값 저장 (디버깅 목적이 아니라면 필수는 아닙니다)
+  const isDataLoadingRef = useRef(isDataLoading);
+
+  // isDataLoading 상태가 바뀔 때마다 ref 업데이트 (디버깅 목적이 아니라면 필수는 아닙니다)
+  useEffect(() => {
+    isDataLoadingRef.current = isDataLoading;
+  }, [isDataLoading]);
 
   const handleRowClick = (customerId: number) => {
     console.log("선택된 customerId:", customerId);
@@ -24,50 +36,65 @@ export default function Page() {
     setSelectedCustomerId(customerId);
     setIsModalOpen(true);
   };
+
   const closeModal = () => {
     setIsModalOpen(false);
     setSelectedCustomerId(null); // 모달 닫기 시 초기화
   };
+
+  useEffect(() => {
+    console.log("상위에서 받은 isDataLoading의 값 : ", isDataLoading);
+  }, [isDataLoading]);
+
   return (
     <div className="flex items-center h-screen">
       <div className="h-full">
         <SideBar />
       </div>
-      {/* 메인콘텐츠 */}
+      {/* 메인 콘텐츠 영역 */}
       <div className="relative h-[900px] flex-[8_0_0] bg-white rounded-xl p-4 max-w-[1500px] w-full">
         <TopControls
           setSearchResults={setSearchResults}
           setOption1={setFilterOption1}
         />
-        <div className="relative h-[790px]">
-          {/* 검색결과가 있을경우 */}
-          {searchResults.length > 0 ? (
-            <div className="grid grid-cols-1 rounded-xl gap-2 p-4 border border-gray-300 h-full overflow-y-auto">
-              {searchResults.map((member, customerId) => (
-                <MemberRow
-                  key={customerId}
-                  member={member}
-                  onClick={() => handleRowClick(member.customerId)}
-                />
-              ))}
-              {/* 모달 */}
-              {isModalOpen && selectedCustomerId && (
-                <>
-                  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <div className="bg-white w-full max-w-4xl p-6 rounded-lg shadow-lg relative">
-                      <DetailMember
-                        customerId={selectedCustomerId}
-                        onClose={closeModal}
-                      />
+
+        {/* ✅ isDataLoading 상태에 따른 조건부 렌더링 로직 시작 */}
+        {
+          <div className="relative h-[790px]">
+            {/* 검색 결과가 있을 경우 */}
+            {searchResults.length > 0 ? (
+              <div className="grid grid-cols-1 rounded-xl gap-2 p-4 border border-gray-300 h-full overflow-y-auto">
+                {searchResults.map((member, index) => (
+                  <MemberRow
+                    key={member.customerId || index}
+                    member={member}
+                    onClick={() => handleRowClick(member.customerId)}
+                  />
+                ))}
+                {/* 모달 (검색 결과용) */}
+                {isModalOpen && selectedCustomerId && (
+                  <>
+                    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+                      <div className="bg-white w-full max-w-4xl p-6 rounded-lg shadow-lg relative">
+                        <DetailMember
+                          customerId={selectedCustomerId}
+                          onClose={closeModal}
+                        />
+                      </div>
                     </div>
-                  </div>
-                </>
-              )}
-            </div>
-          ) : (
-            <MemberList selectedOption1={filterOption1} />
-          )}
-        </div>
+                  </>
+                )}
+              </div>
+            ) : (
+              // 검색 결과가 없을 경우, 일반 회원 목록을 보여줍니다.
+              <MemberList
+                selectedOption1={filterOption1}
+                setIsDataLoading={setIsDataLoading} // ✅ setIsDataLoading 함수를 MemberList에 전달
+              />
+            )}
+          </div>
+        }
+        {/* ✅ 조건부 렌더링 로직 끝 */}
       </div>
     </div>
   );


### PR DESCRIPTION
## ✨ 주요 변경 사항
네비게이션바에서 첫번째 버튼인 멤버 리스트 버튼을 눌렀을 때 컴포넌트가 모두 로딩된 이후에야 
---

## 🛠 작업 방식
- members 탭에 로딩중 화면 추가
- API 정보를 모두 받아왔는지를 isLoading으로 확인한 이후, '정보를 불러오고 있습니다'라고 적힌 페이지 추가
---

## 📸 UI 스크린샷


<loading페이지 추가 전>

https://github.com/user-attachments/assets/c6262104-40cc-451a-9c76-d5554beb94ec

<loading페이지 추가 후>

https://github.com/user-attachments/assets/83489438-6779-491a-a5bc-da7c0eaedcae

---

## ❗ 기타 참고 사항
수정 이후에도 버튼을 누르자마자 바로 반응하지는 않아서, 지연 문제를 더 빠르게 해결할 수 있는 방법을 추가로 찾아보고 있습니다