### PR TITLE
feat: 예약 페이지 요일 추가

### DIFF
--- a/src/app/members/loading.tsx
+++ b/src/app/members/loading.tsx
@@ -2,7 +2,6 @@ export default function loading() {
   return (
     <div className="text-center text-lg font-semibold text-gray-700">
       <p>회원 정보를 불러오는 중입니다...</p>
-      <div className="mt-4 animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
     </div>
   );
 }

--- a/src/utils/calendar/calendarSetup.ts
+++ b/src/utils/calendar/calendarSetup.ts
@@ -5,8 +5,11 @@ import interactionPlugin from "@fullcalendar/interaction";
 import dayjs from "dayjs";
 import { CalendarSetupProps } from "@/types/eventType";
 import timezone from "dayjs/plugin/timezone";
+import "dayjs/locale/ko";
 
 dayjs.extend(timezone);
+
+dayjs.locale("ko");
 
 export const calendarSetup = ({
   calendarRef,
@@ -37,7 +40,7 @@ export const calendarSetup = ({
     // default basic setting
     // timeZone: "Asia/Seoul",
     // 개발 시에만 local
-    timeZone: 'local',
+    timeZone: "local",
     allDaySlot: false,
     slotMinWidth: 5,
     height: "100%",
@@ -106,7 +109,8 @@ export const calendarSetup = ({
     // Set customTitle button based on currentDate
     datesSet: (info) => {
       const currentDate = dayjs(info.view.currentStart).tz("Asia/Seoul");
-      const formatted = dayjs(currentDate).format("M월 D일");
+
+      const formatted = dayjs(currentDate).format("M월 D일 dddd");
 
       const customTitleButton = calendarRef.current?.querySelector(
         ".fc-customTitle-button.fc-button.fc-button-primary"


### PR DESCRIPTION
## ✨ 주요 변경 사항  

예약 관리 페이지에서 날짜 옆에 요일을 추가했습니다

## 🛠 작업 방식
Day.js 라이브러리에서 dayjs 를 이용하여 
```tsx
format("M월 D일 dddd")
```
를 이용하여 local형태로 변환한 요일을 추가한다 
---

## 📸 UI 스크린샷
<수정 전>
![image](https://github.com/user-attachments/assets/ea7914df-7b1b-4721-998b-408110f35885)


<수정 후>
![image](https://github.com/user-attachments/assets/b7013eb0-79f9-4e13-8b0b-c8cc190993b1)

---

## ❗ 기타 참고 사항