### PR TITLE
fix: 예약 추가API 호출시 시간 query추가

### DIFF
--- a/src/api/reservation/postAddReservations.ts
+++ b/src/api/reservation/postAddReservations.ts
@@ -26,8 +26,12 @@ export const postAddReservations = async (userInfo: {
       console.log("예약 성공", response);
       console.log("startStr:", userInfo.startStr); // "2025-07-01T08:00"
       console.log(
-        "시간 인덱스:",
+        "startIdx:",
         timeMapping[userInfo.startStr.split("T")[1].slice(0, 5)]
+      );
+      console.log(
+        "endIdx : ",
+        timeMapping[`${userInfo?.endStr.split("T")[1].slice(0, 5)}`]
       );
     }
   } catch (error: unknown) {

--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -119,7 +119,10 @@ const SelectedEventModal: React.FC<EventProps> = ({
       const response = await postAddReservations({
         ...userInfo,
         customerId: userInfo.customerId,
+        startIndex: userInfo.startIndex,
+        endIndex: userInfo.endIndex,
       });
+      console.log("보낼 정보 : ", userInfo);
       setTimeout(async () => {
         await refreshCalendar();
       }, 1000);


### PR DESCRIPTION
## ✨ 주요 변경 사항

예약 추가 API호출 시 startIndex, endIndex query를 추가하였습니다

## 🛠 작업 방식

```tsx
const response = await postAddReservations({
        ...userInfo,
        customerId: userInfo.customerId,
        startIndex: userInfo.startIndex,
        endIndex: userInfo.endIndex,
      });
```

## 📸 UI 스크린샷

## ❗ 기타 참고 사항