### PR TITLE
fix/예약 추가시 진도표 스크롤 추가

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -215,9 +215,7 @@ export default function ReservationContent({
           <div>
             <div className="text-left m-1 font-semibold">진도표</div>
             <div
-              className={`mt-2 w-[320px] rounded-lg border border-[#D1D1D1] bg-white px-2 py-2 overflow-y-auto ${
-                event?.mode === "edit" ? "h-[251px]" : "min-h-[180px]"
-              }`}
+              className={`mt-2 w-[320px] rounded-lg border border-[#D1D1D1] bg-white px-2 py-2 overflow-y-auto max-h-[250px] min-h-[180px]`}
             >
               {userInfo?.progressList?.filter((p: any) => !p.deleted).length >
               0 ? (

--- a/src/app/components/reservation/reservationModal/ReservationModal.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationModal.tsx
@@ -7,17 +7,21 @@ import {
 } from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Calendar } from "@fullcalendar/core";
-
+import { SelectedRangeId } from "@/types/eventType";
 interface ReservationModalProps {
   selectedEvent: any;
   onClose: () => void;
   calendarInstance: React.MutableRefObject<Calendar | null>;
+  setSelectedRangeId: React.Dispatch<
+    React.SetStateAction<SelectedRangeId | null>
+  >;
 }
 
 const ReservationModal: React.FC<ReservationModalProps> = ({
   selectedEvent,
   onClose,
   calendarInstance,
+  setSelectedRangeId,
 }) => {
   return (
     <Dialog open={!!selectedEvent} onOpenChange={(open) => !open && onClose()}>

--- a/src/app/reservation/page.tsx
+++ b/src/app/reservation/page.tsx
@@ -4,16 +4,20 @@ import { Calendar } from "@fullcalendar/core";
 import SideBar from "../components/SideBar";
 import Reservation from "../components/reservation/Reservation";
 import ReservationModal from "../components/reservation/reservationModal/ReservationModal";
-import { SelectedEvent } from "@/types/eventType";
+import { SelectedEvent, SelectedRangeId } from "@/types/eventType";
 
 export default function Page() {
   const [selectedEvent, setSelectedEvent] = useState<null | SelectedEvent>(
     null
   );
+  const [selectedRangeId, setSelectedRangeId] =
+    useState<SelectedRangeId | null>(null);
+
   const calendarRef = useRef<HTMLDivElement>(null);
   const calendarInstance = useRef<Calendar>(null);
 
   console.log("selectedEvent", selectedEvent);
+  console.log("selectedRangeId", selectedRangeId); // ✨ 새로운 상태를 콘솔에 출력
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -36,6 +40,8 @@ export default function Page() {
         selectedEvent={selectedEvent}
         onClose={() => setSelectedEvent(null)}
         calendarInstance={calendarInstance}
+        // ✨ ReservationModal에도 필요하다면 selectedRangeId와 setter 함수를 전달
+        setSelectedRangeId={setSelectedRangeId}
       />
     </div>
   );

--- a/src/types/eventType.ts
+++ b/src/types/eventType.ts
@@ -29,3 +29,8 @@ export interface CalendarSetupProps {
   setSelectedEvent: React.Dispatch<React.SetStateAction<SelectedEvent | null>>;
   now: Dayjs;
 }
+
+export interface SelectedRangeId {
+  formattedStartTime: string | null;
+  formattedEndTime: string | null;
+}


### PR DESCRIPTION
## ✨ 주요 변경 사항

edit의 경우 진도표의 개수가 늘어나면 스크롤 기능이 생겼지만, 
add의 경우 진도표의 크기만큼 표의 크기가 유동적으로 늘어나서 전체 모달의 크기가 커졌고, 이에 따라 저장버튼이 보이지 않는 오류가 발생하였습니다

## 🛠 작업 방식

edit, add모드에 따라서 진도표의 높이를 유동적으로 변경했으나, 모드에 상관없이 높이를 고정할 수 있도록 하였다
```tsx
<div
    className={`mt-2 w-[320px] rounded-lg border border-[#D1D1D1] bg-white px-2 py-2 
    overflow-y-auto max-h-[250px] min-h-[180px]`}
>
```

## 📸 UI 스크린샷
<img width="2213" height="1074" alt="image" src="https://github.com/user-attachments/assets/ff2d3a3c-be0f-4bb9-990d-39157d65c5d1" />

## ❗ 기타 참고 사항