### PR TITLE
fix/진도표 내용 입력 여부에 따라 버튼에 disabled속성 부여

### DIFF
--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -43,6 +43,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
   const [userInfo, setUserInfo] = useState<any>(null);
   const [editProgress, setEditProgress] = useState<any>(null);
   const [progressUsedTime, setProgressUsedTime] = useState(""); // 시간 입력 상태
+  const [isInput, setIsInput] = useState(false); //진도표 수정에 값 입력 여부
 
   useEffect(() => {
     if (event?.mode == "add") {
@@ -294,7 +295,9 @@ const SelectedEventModal: React.FC<EventProps> = ({
       setCustomerList([]);
     }
   };
-
+  useEffect(() => {
+    setIsInput(!progressContent?.trim());
+  }, [progressContent]);
   return (
     <>
       <div className="flex flex-col">
@@ -326,7 +329,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
               type="text"
               className="w-full h-[80px] p-2 border bg-[#F2F8ED] border-[#B4D89C] rounded-lg"
               placeholder="진도표 내용을 입력하세요"
-              value={progressContent}
+              value={progressContent ?? ""}
               onChange={(e) => setProgressContent(e.target.value)}
             />
 
@@ -334,8 +337,12 @@ const SelectedEventModal: React.FC<EventProps> = ({
             <div className="flex justify-center mt-4">
               <BasicButton
                 color="primary"
-                className="w-full"
+                // Conditionally apply gray background and 'not-allowed' cursor when disabled
+                className={`w-full ${
+                  isInput ? "bg-gray-400 cursor-not-allowed" : ""
+                }`}
                 onClick={handleConfirmProgress}
+                disabled={isInput} // Disable the button based on the isInput state
               >
                 확인
               </BasicButton>


### PR DESCRIPTION
## ✨ 주요 변경 사항

이전에는 진도표 수정 영역에 입력 값이 없는 경우 확인버튼을 눌러도 모달이 사라지지 않을 뿐만 아니라 경고메세지 없이 더 이상 진행이 안되었습니다

수정 이후에는 입력값이 있는 경우에만 확인버튼이 활성화 될 수 있도록 수정하였습니다

## 🛠 작업 방식

isInput 값으로 input의 존재 여부를 확인한 후, 이에 따라 disabled 속성을 class에 부여했다

## 📸 UI 스크린샷
<수정 전>

https://github.com/user-attachments/assets/72ea2c8e-5481-4b35-b1d9-0f7530326701

<수정 후>

https://github.com/user-attachments/assets/cde6d2b4-6369-4760-a310-507f6c9b0c55

## ❗ 기타 참고 사항