### PR TITLE
fix : 진도표 수정 모달 날짜 오류 수정

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationModal.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationModal.tsx
@@ -8,6 +8,7 @@ import {
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Calendar } from "@fullcalendar/core";
 import { SelectedRangeId } from "@/types/eventType";
+import { useEffect } from "react";
 interface ReservationModalProps {
   selectedEvent: any;
   onClose: () => void;
@@ -23,6 +24,11 @@ const ReservationModal: React.FC<ReservationModalProps> = ({
   calendarInstance,
   setSelectedRangeId,
 }) => {
+  useEffect(() => {
+    console.log("event : ", selectedEvent);
+    console.log("onClose: ", onclose);
+    console.log("calenderInstatce : ", calendarInstance);
+  }, []);
   return (
     <Dialog open={!!selectedEvent} onOpenChange={(open) => !open && onClose()}>
       <DialogOverlay className="fixed inset-0 bg-black bg-opacity-50 z-40" />

--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -72,6 +72,8 @@ const SelectedEventModal: React.FC<EventProps> = ({
   }, [event]);
 
   const handleEditProgress = (progress: any) => {
+    console.log("progress: ", progress);
+    setClickedDate(progress.date);
     setEditProgress(progress);
     setProgressContent(progress.content);
     setProgressUsedTime(progress.usedTime);
@@ -166,7 +168,6 @@ const SelectedEventModal: React.FC<EventProps> = ({
             content: p.content,
           })),
         });
-
         console.log("✅ 예약 및 진도 수정 완료", response);
         await refreshCalendar();
         onClose();
@@ -189,6 +190,8 @@ const SelectedEventModal: React.FC<EventProps> = ({
   const [showProgressModal, setShowProgressModal] = useState(false);
   const [progressContent, setProgressContent] = useState("");
   const currentDate = new Date().toISOString().split("T")[0];
+
+  const [clickedDate, setClickedDate] = useState(currentDate);
 
   const handleAddIcon = () => {
     setShowProgressModal(true);
@@ -321,7 +324,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
 
             {/* 진도표 날짜 */}
             <div className="mb-4 p-2 border bg-[#F6F6F6] border-[#D1D1D1] rounded-lg text-center">
-              {currentDate}
+              {clickedDate}
             </div>
 
             {/* 진도표 내용 입력 필드 */}


### PR DESCRIPTION
## ✨ 주요 변경 사항
### 1. 수정 전
진도표 수정을 위해 진도표 리스트에서 목록을 누르면 누른 날짜와 상관없이 오늘 날짜가 뜨는 오류가 발생함

### 2. 수정 후
클릭한 진도표에 맞는 날짜가 뜰 수 있도록 수정하였습니다

## 🛠 작업 방식
ReservationContent에서 전달하는 progress 중 date에 해당하는 정보를 클릭할 때 마다 상위에서 받아 사용하는 방식으로 수정하였습니다.
상위 컴포넌트인 SelectedEventModal에서 clickedDate라는 변수를 useState로 관리하며 값을 매번 업데이트 하여 클린한 목록에 따른 날짜가 나올 수 있도록 하였습니다

## 📸 UI 스크린샷
### 1. 수정 전

https://github.com/user-attachments/assets/1b9b6500-ce7e-4b06-8563-03afeb22f160

### 2. 수정 후

https://github.com/user-attachments/assets/16a9bf5e-cc22-487c-a46b-f2908a6067a2

## ❗ 기타 참고 사항