### PR TITLE
fix:instituteInfo API를 이용하여 예약 캘린더 동적 반응 수정

### DIFF
--- a/src/api/institute/instituteInfo.ts
+++ b/src/api/institute/instituteInfo.ts
@@ -1,0 +1,18 @@
+import apiClient from "../core/apiClient";
+import errorHandler from "../core/errorHandler";
+
+export const instituteAPI = {
+  /**
+   * 매장 정보 조회 method
+   * @return 매장 시작, 종료시간, 전체 좌석 수
+   */
+  getInstituteInfo: async () => {
+    try {
+      const response = await apiClient.get("/api/institute/info");
+      return response.data.data; // 서버 응답의 `data` 필드에 리스트가 포함됨
+    } catch (error: unknown) {
+      const errorMessage = errorHandler(error);
+      throw new Error(errorMessage);
+    }
+  },
+};

--- a/src/app/components/reservation/Reservation.tsx
+++ b/src/app/components/reservation/Reservation.tsx
@@ -11,10 +11,16 @@ function Reservation({
   setSelectedEvent,
   calendarRef,
   calendarInstance,
+  totalSeats,
+  startTime,
+  endTime,
 }: {
   setSelectedEvent: React.Dispatch<React.SetStateAction<SelectedEvent | null>>;
   calendarRef: React.MutableRefObject<HTMLDivElement | null>;
   calendarInstance: React.MutableRefObject<Calendar | null>;
+  totalSeats: number | null;
+  startTime: string | null;
+  endTime: string | null;
 }) {
   const now = dayjs();
   const [showMiniCalendar, setShowMiniCalendar] = useState(false);
@@ -22,7 +28,11 @@ function Reservation({
   const nowDate = clickedDate?.format("YYYY-MM-DD");
 
   useEffect(() => {
-    if (calendarRef.current) {
+    if (calendarRef.current && startTime && endTime && totalSeats) {
+      const totalSeatsObj = Array.from({ length: totalSeats }, (_, i) => ({
+        id: (i + 1).toString(),
+        title: (i + 1).toString(),
+      }));
       calendarInstance.current = calendarSetup({
         calendarRef,
         clickedDate,
@@ -30,7 +40,13 @@ function Reservation({
         setShowMiniCalendar,
         setSelectedEvent,
         now,
+        startTime,
+        endTime,
+        totalSeatsObj,
       });
+      console.log("in reservation.tsx");
+      console.log(startTime, endTime, totalSeats);
+      console.log(totalSeatsObj);
     }
 
     return () => {
@@ -39,7 +55,14 @@ function Reservation({
         calendarInstance.current = null;
       }
     };
-  }, [calendarRef, calendarInstance, setSelectedEvent]);
+  }, [
+    calendarRef,
+    calendarInstance,
+    setSelectedEvent,
+    startTime,
+    endTime,
+    totalSeats,
+  ]);
 
   useEffect(() => {
     if (calendarInstance.current) {

--- a/src/app/components/reservation/reservationModal/ReservationModal.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationModal.tsx
@@ -24,11 +24,6 @@ const ReservationModal: React.FC<ReservationModalProps> = ({
   calendarInstance,
   setSelectedRangeId,
 }) => {
-  useEffect(() => {
-    console.log("event : ", selectedEvent);
-    console.log("onClose: ", onclose);
-    console.log("calenderInstatce : ", calendarInstance);
-  }, []);
   return (
     <Dialog open={!!selectedEvent} onOpenChange={(open) => !open && onClose()}>
       <DialogOverlay className="fixed inset-0 bg-black bg-opacity-50 z-40" />

--- a/src/app/reservation/page.tsx
+++ b/src/app/reservation/page.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Calendar } from "@fullcalendar/core";
 import SideBar from "../components/SideBar";
 import Reservation from "../components/reservation/Reservation";
 import ReservationModal from "../components/reservation/reservationModal/ReservationModal";
 import { SelectedEvent, SelectedRangeId } from "@/types/eventType";
-
+import { adminAPI } from "@/api/admin/institute";
+import { isNil } from "lodash";
+import { instituteAPI } from "@/api/institute/instituteInfo";
 export default function Page() {
   const [selectedEvent, setSelectedEvent] = useState<null | SelectedEvent>(
     null
@@ -13,11 +15,34 @@ export default function Page() {
   const [selectedRangeId, setSelectedRangeId] =
     useState<SelectedRangeId | null>(null);
 
+  const [startTime, setStartTime] = useState("08:00:00");
+  const [endTime, setEndTime] = useState("22:00:00");
+  const [instituteCount, setInstituteCount] = useState(4);
+
   const calendarRef = useRef<HTMLDivElement>(null);
   const calendarInstance = useRef<Calendar>(null);
 
   console.log("selectedEvent", selectedEvent);
   console.log("selectedRangeId", selectedRangeId); // ✨ 새로운 상태를 콘솔에 출력
+
+  useEffect(() => {
+    const fetchInstituteData = async () => {
+      try {
+        const instituteData = await instituteAPI.getInstituteInfo();
+        console.log("Fetched instituteData: ", instituteData);
+        const totalSeats = instituteData.totalSeat;
+        const startTime = instituteData.openTime;
+        const endTime = instituteData.closeTime;
+        setInstituteCount(totalSeats);
+        setStartTime(startTime);
+        setEndTime(endTime);
+      } catch (error: any) {
+        console.error("Error fetching institute data:", error);
+      }
+    };
+
+    fetchInstituteData();
+  }, []);
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -29,6 +54,9 @@ export default function Page() {
       {/* Reservation */}
       <div className="h-full flex-[95_0_0] self-center mr-[130px] py-10 overflow-hidden">
         <Reservation
+          startTime={startTime}
+          endTime={endTime}
+          totalSeats={instituteCount}
           setSelectedEvent={setSelectedEvent}
           calendarRef={calendarRef}
           calendarInstance={calendarInstance}

--- a/src/types/eventType.ts
+++ b/src/types/eventType.ts
@@ -28,6 +28,9 @@ export interface CalendarSetupProps {
   setShowMiniCalendar: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedEvent: React.Dispatch<React.SetStateAction<SelectedEvent | null>>;
   now: Dayjs;
+  startTime: string | null;
+  endTime: string | null;
+  totalSeatsObj: object;
 }
 
 export interface SelectedRangeId {

--- a/src/utils/calendar/calendarSetup.ts
+++ b/src/utils/calendar/calendarSetup.ts
@@ -18,6 +18,9 @@ export const calendarSetup = ({
   setShowMiniCalendar,
   setSelectedEvent,
   now,
+  startTime,
+  endTime,
+  totalSeatsObj,
 }: CalendarSetupProps) => {
   if (!calendarRef.current) return null;
 
@@ -28,8 +31,8 @@ export const calendarSetup = ({
     // Set library plugins and initial View
     plugins: [resourceTimeGridPlugin, dayGridPlugin, interactionPlugin],
     initialView: "resourceTimeGridDay",
-    slotMinTime: "08:00:00",
-    slotMaxTime: "22:59:59",
+    slotMinTime: startTime,
+    slotMaxTime: endTime,
     slotDuration: "00:30:00",
     scrollTime: currentTime,
     expandRows: true,
@@ -44,12 +47,8 @@ export const calendarSetup = ({
     slotEventOverlap: false,
 
     // Set calendar resources
-    resources: [
-      { id: "1", title: "1" },
-      { id: "2", title: "2" },
-      { id: "3", title: "3" },
-      { id: "4", title: "4" },
-    ],
+
+    resources: totalSeatsObj,
 
     // Set event items
     events: [],


### PR DESCRIPTION
## ✨ 주요 변경 사항

예약 페이지에서 시작 시간, 종료 시간, 좌석 수를 고정으로 지정해두던 캘린더를 API에서 받아온 값에 따라 시간을 달리할 수 있도록 수정하였습니다

## 🛠 작업 방식

@fullcalendar 라이브러리를 사용하고 있는 것을 확인한 후, 최상위페이지에서 받은 시작, 종료시간과 좌석 개수를 라이브러리에서 요청하는 형식에 맞게 객체를 생성하여 할당하였습니다

## 📸 UI 스크린샷
<img width="2169" height="1273" alt="image" src="https://github.com/user-attachments/assets/ffb1222f-36d9-48ee-b7fd-3911ea7e7c1b" />


## ❗ 기타 참고 사항
다음에도 캘린더를 수정할 상황이 생기면 [@fullcalendar ](https://fullcalendar.io/) 해당 사이트를 확인해보는 것이 좋을 것 같습니다