### PR TITLE
feat: 예약 페이지 예약 색상 고정

### DIFF
--- a/src/utils/calendar/colorList.ts
+++ b/src/utils/calendar/colorList.ts
@@ -1,14 +1,1 @@
-export const colorList = [
-  "#B4D89C",
-  "#FFCB9B",
-  "#9CD8CD",
-  "#A59CD8",
-  "#D89CB9",
-  "#F9EE74",
-  "#9EDCF3",
-  "#D39CD8",
-  "#A7FFDB",
-  "#FF9277",
-  "#9CBAD8",
-  "#F0FE73",
-];
+export const colorList = ["#77A461"];


### PR DESCRIPTION
## ✨ 주요 변경 사항
기존에는 7개정도의 색상을 랜덤으로 배정하여 예약의 색상을 지정하였습니다. 하지만, 화면을 새로고침 할 때마다 색상이 변경되는 문제점이 존재하기 때문에 1차적으로 색상을 고정해둔 상태입니다

## 🛠 작업 방식
color List에 있는 목록을 제거하고 하나의 색상으로 변경하였습니다 
## 📸 UI 스크린샷
<img width="2192" height="1206" alt="image" src="https://github.com/user-attachments/assets/d4f89d26-75d1-49ae-8604-87cc6882b0b3" />

## ❗ 기타 참고 사항
1. 사전적인 조치로 id의 길이에 따라 특정 길이가 넘어가면 색상이 변경되도록 수정하려고 합니다
2. 추가로 API가 완성된 이후에는 시간제, 기간제에 따라 색상을 다르게 변경할 예정입니다