### PR TITLE
fix: 예약 시간 조정창 수정

### DIFF
--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -1,6 +1,4 @@
 import Image from "next/image";
-import { handleTimeInputChange } from "@/utils/reservation/handleTimeInputChange";
-import { putUpdateReservations } from "@/api/reservation/putUpdateReservations";
 import { useEffect, useState } from "react";
 import _ from "lodash";
 
@@ -26,6 +24,39 @@ interface Props {
   setEndTime: (endTime: string) => void;
 }
 
+// 유틸 함수
+function minutesToTimeString(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}
+
+function timeStringToMinutes(time: string): number {
+  const [h, m] = time.split(":");
+  return Number(h) * 60 + Number(m);
+}
+
+function handleStepTimeChange(
+  newMinutes: number,
+  type: "start" | "end",
+  setUserInfo: any,
+  setTimeError: any,
+  setIsValid: any,
+  setTime: any,
+  isValid: boolean
+) {
+  const timeStr = minutesToTimeString(newMinutes);
+
+  setUserInfo((prev: any) => ({
+    ...prev,
+    [type === "start" ? "formattedStartTime" : "formattedEndTime"]: timeStr,
+  }));
+  setTime(timeStr);
+
+  setIsValid(true);
+  setTimeError("");
+}
+
 export default function ReservationContent({
   userInfo,
   setUserInfo,
@@ -44,21 +75,13 @@ export default function ReservationContent({
   const [isValid, setIsValid] = useState<boolean>(true);
 
   useEffect(() => {
-    console.log("isValid : ", isValid);
-  }, [isValid, setIsValid]);
-  useEffect(() => {
     setStartTime(userInfo?.formattedStartTime);
     setEndTime(userInfo?.formattedEndTime);
   }, []);
+
   return (
-    // Main container: Ensure minimal padding and allow wrapping.
-    // Changed md:flex-row to sm:flex-row for an earlier horizontal layout, if desired.
-    // Added min-w-0 to the main flex container to allow it to shrink.
     <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 items-start w-full min-w-0 mx-auto p-2">
-      {/* Left column: User photo and Basic Info */}
-      {/* Ensure this column can shrink as well if needed. */}
       <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto flex-[1.6] min-w-0">
-        {/* User photo */}
         <div className="justify-center mx-auto sm:m-1 size-24 sm:size-32 flex-shrink-0">
           <Image
             src={userInfo?.photoUrl || "/reservationModal/noUser.png"}
@@ -69,52 +92,73 @@ export default function ReservationContent({
           />
         </div>
 
-        {/* basic info */}
-        {/* Changed md:max-w-[250px] to just max-w-full on smaller screens, and let flex-grow handle it. */}
         <div className="flex flex-col mx-2 w-full max-h-[600px] overflow-y-auto space-y-2 text-sm md:text-base flex-1 min-w-0">
           <div className="flex justify-between text-left m-1 font-semibold text-base md:text-lg">
             예약 시간
           </div>
           <div className="flex flex-row gap-1 w-full">
-            <input
-              className="flex-1 font-light bg-[#F2F8ED] border border-[#B4D89C] p-[8px_12px] rounded-lg text-[#3C6229] min-h-7 min-w-0 text-sm md:text-base"
-              type="text"
-              maxLength={5}
-              value={userInfo?.formattedStartTime || ""}
-              placeholder="--:--"
-              onChange={(e) => {
-                handleTimeInputChange(
-                  e.target.value,
-                  "start",
-                  setUserInfo,
-                  setTimeError,
-                  setIsValid,
-                  setStartTime,
-                  isValid
-                );
-              }}
-            />
+            <div className="flex flex-col w-full relative">
+              <input
+                type="number"
+                step={30}
+                min={0}
+                max={1440}
+                value={
+                  userInfo?.formattedStartTime
+                    ? timeStringToMinutes(userInfo.formattedStartTime)
+                    : ""
+                }
+                onChange={(e) =>
+                  handleStepTimeChange(
+                    Number(e.target.value),
+                    "start",
+                    setUserInfo,
+                    setTimeError,
+                    setIsValid,
+                    setStartTime,
+                    isValid
+                  )
+                }
+                className="font-light bg-[#F2F8ED] border border-[#B4D89C] p-[8px_12px] rounded-lg text-transparent text-sm md:text-base"
+              />
+              {/* 변환된 시간 보여주기 */}
+              <div className="absolute left-3 top-1/2 transform -translate-y-1/2 text-sm text-black pointer-events-none">
+                {userInfo?.formattedStartTime}
+              </div>
+            </div>
+
             <div className="font-light p-2 min-h-7 text-sm md:text-base flex-shrink-0">
               ~
             </div>
-            <input
-              className="flex-1 font-light bg-[#F2F8ED] border border-[#B4D89C] p-[8px_12px] rounded-lg text-[#3C6229] min-h-7 min-w-0 text-sm md:text-base"
-              type="text"
-              maxLength={5}
-              value={userInfo?.formattedEndTime || ""}
-              placeholder="--:--"
-              onChange={(e) =>
-                handleTimeInputChange(
-                  e.target.value,
-                  "end",
-                  setUserInfo,
-                  setTimeError,
-                  setIsValid,
-                  setEndTime,
-                  isValid
-                )
-              }
-            />
+            <div className="flex flex-col w-full relative">
+              <input
+                type="number"
+                step={30}
+                min={0}
+                max={1440}
+                value={
+                  userInfo?.formattedEndTime
+                    ? timeStringToMinutes(userInfo.formattedEndTime)
+                    : ""
+                }
+                onChange={(e) =>
+                  handleStepTimeChange(
+                    Number(e.target.value),
+                    "end",
+                    setUserInfo,
+                    setTimeError,
+                    setIsValid,
+                    setStartTime,
+                    isValid
+                  )
+                }
+                className="font-light bg-[#F2F8ED] border border-[#B4D89C] p-[8px_12px] rounded-lg text-transparent text-sm md:text-base"
+              />
+              {/* 변환된 시간 보여주기 */}
+              <div className="absolute left-3 top-1/2 transform -translate-y-1/2 text-sm text-black pointer-events-none">
+                {userInfo?.formattedEndTime}
+              </div>
+            </div>
           </div>
           {timeError && (
             <div className="text-red-500 text-xs md:text-sm mt-1">
@@ -172,8 +216,6 @@ export default function ReservationContent({
               </div>
             </div>
             <div className="flex flex-row gap-1 w-full">
-              {" "}
-              {/* Added w-full */}
               <div className="flex-1 font-light bg-[#F6F6F6] border border-[#D1D1D1] p-[8px_12px] rounded-lg text-[#888888] min-h-7 min-w-0 text-sm md:text-base">
                 {userInfo?.endDate?.split("T")[0] || ""}
               </div>
@@ -189,6 +231,7 @@ export default function ReservationContent({
           <div className="w-full font-light bg-[#F6F6F6] p-[8px_12px] rounded-lg border border-[#D1D1D1] text-[#888888] min-h-7 text-sm md:text-base">
             {userInfo?.planName || ""}
           </div>
+
           {event?.mode === "edit" && (
             <div>
               <div className="text-left m-1 font-semibold text-base md:text-lg">
@@ -245,8 +288,6 @@ export default function ReservationContent({
         </div>
       </div>
 
-      {/* Right column: Member Memo and Progress List */}
-      {/* Changed md:w-[320px] to flex-1 and min-w-0 to allow it to shrink. */}
       <div className="flex flex-col gap-4 w-full flex-1 min-w-0">
         <div className="w-full">
           <div className="text-left m-1 font-semibold text-base md:text-lg">
@@ -276,8 +317,7 @@ export default function ReservationContent({
                 .map((p: any) => (
                   <div
                     key={`${p.progressId}-${p.date}`}
-                    className="w-full h-[53px] mb-2 px-[10px] py-[8px] rounded-lg flex justify-between items-start
-           border border-[#D1D1D1] hover:border-[#B4D89C] hover:border-2 transition-all duration-150 cursor-pointer"
+                    className="w-full h-[53px] mb-2 px-[10px] py-[8px] rounded-lg flex justify-between items-start border border-[#D1D1D1] hover:border-[#B4D89C] hover:border-2 transition-all duration-150 cursor-pointer"
                     onClick={() => handleEditProgress(p)}
                   >
                     <div className="flex flex-col justify-start">
@@ -293,9 +333,8 @@ export default function ReservationContent({
                         {p.content || "내용 없음"}
                       </div>
                     </div>
-
                     {p.usedTime && (
-                      <div className="text-black text-[13px] md:text-[14px] font-normal font-['Inter'] leading-[120%]">
+                      <div className="text-black text-[13px] md:text-[14px] font-normal leading-[120%]">
                         {p.usedTime.toString().replace(/\.0$/, "")}H
                       </div>
                     )}


### PR DESCRIPTION
## ✨ 주요 변경 사항
기존 예약 페이지에서 예약 시간은 사용자가 직접 시간을 입력할 수 있는 input창 형태로 되어있었습니다. 하지만, 30분 단위로 시간을 입력해야 하고, 영업시간 안에서 시간을 입력해야 한다는 불편함을 해결하기 위해 화살표를 이용하여 예약 시간을 바꿀 수 있도록 수정하였습니다

현재 화살표는 30분 단위로 시간이 변경되도록 하였습니다 

## 🛠 작업 방식
### 1. 구현 배경

사용자가 화살표를 클릭해 간편하게 시간을 조절하는 기능을 제공하고자 했습니다. 해당 기능은 HTML input 태그의 타입을 'number'로 설정해야 구현 가능합니다.

### 2. 문제점

input 타입을 'number'로 설정하면 시간(예: 10:00)을 분 단위의 숫자(예: 600)로 변환해서 값을 다뤄야 합니다. 이 숫자 값이 입력창에 그대로 노출될 경우, 사용자가 직관적으로 시간을 인지하기 어렵기에 불편합니다.

### 3. 해결 방안

기존 숫자는 투명하게 처리하여 화면에 보이지 않도록 합니다. 투명해진 입력창 위로 실제 시간을 보여주는 새로운 div 창을 배치합니다. 사용자가 화살표로 값을 조절하면, 보이지 않는 input의 숫자 값이 변경되고, 이 값을 즉시 시간 형식으로 변환하여 div 창에 보여줍니다. 결과적으로, 기술적 제약을 해결하면서도 사용자는 시간을 직접 선택하고 조절하는 듯하도록 하였습니다

## 📸 UI 스크린샷

https://github.com/user-attachments/assets/54685680-311f-4349-8504-eb7e42e5534a

## ❗ 기타 참고 사항
