### PR TITLE
fix: miniCalanderPop 외부를 클릭해도 꺼지도록 수정

### DIFF
--- a/src/app/components/reservation/Reservation.tsx
+++ b/src/app/components/reservation/Reservation.tsx
@@ -75,13 +75,21 @@ function Reservation({
     calendarInstance.current?.gotoDate(date);
   };
 
+  const handleCalanderPopupClick = () => {
+    setShowMiniCalendar(false);
+  };
+
   return (
     <div className="h-full bg-white py-2 px-5 rounded-3xl ">
-      <div ref={calendarRef} id="calendar" className="h-full" />
-
+      <div ref={calendarRef} id="calendar" className="h-full" />{" "}
       {showMiniCalendar && (
-        <MiniCalendarPopup onDateClick={handleMiniCalendarDateClick} />
-      )}
+        <div
+          className="fixed inset-0 flex justify-center items-center z-[90]"
+          onClick={handleCalanderPopupClick}
+        >
+          <MiniCalendarPopup onDateClick={handleMiniCalendarDateClick} />{" "}
+        </div>
+      )}{" "}
     </div>
   );
 }

--- a/src/app/components/reservation/miniCalendar/MiniCalendarPopup.tsx
+++ b/src/app/components/reservation/miniCalendar/MiniCalendarPopup.tsx
@@ -8,12 +8,16 @@ interface MiniCalendarPopupProps {
 const MiniCalendarPopup: React.FC<MiniCalendarPopupProps> = ({
   onDateClick,
 }) => (
-  <div className="absolute top-[55px] left-[39%] z-[100]">
+  <div
+    className="absolute top-[55px] z-[100]"
+    onClick={(e) => e.stopPropagation()}
+  >
+    {" "}
     <MiniCalendar
       onDateClick={(date) => {
         onDateClick(date);
       }}
-    />
+    />{" "}
   </div>
 );
 


### PR DESCRIPTION
## ✨ 주요 변경 사항
기존에 미니캘린더는, 날짜를 선택하지 않으면 팝업이 꺼지지 않도록 되어있었습니다. 하지만, 사용에 불편함이 있을 것을 예상하여 캘린더 외부를 클릭하더라도 팝업이 정상적으로 꺼질 수 있도록 수정하였습니다.

## 🛠 작업 방식
기존에는 miniCalanderPopup 컴포넌트가 미니 캘린더와 이를 감싸는 div 태그로 구성되어 있었지만, 최상위 컴포넌트인 reservation 파일에서 onClick 이벤트를 관리하기 위해 구조를 변경했습니다.

이제 미니 캘린더를 감싸는 div 태그는 reservation 파일로 옮겨졌고, 이 div 태그에 onClick 함수가 부여되어 showMiniCalendar 변수를 제어하게 됩니다.

결론적으로, 미니 캘린더의 표시 여부를 reservation 파일에서 직접 관리하도록 컴포넌트 간의 책임이 분리되었습니다.

## 📸 UI 스크린샷

https://github.com/user-attachments/assets/418eaae7-e3c0-4259-aba2-17083f35155d

## ❗ 기타 참고 사항
