### PR TITLE
fix: sidebar 예약 캘린더 선택했을 때 이미지 변경

### DIFF
--- a/src/app/components/SideBar.tsx
+++ b/src/app/components/SideBar.tsx
@@ -59,7 +59,7 @@ function SideBar() {
         <Button className="py-6" onClick={handleNavigateUserCalendar}>
           <Image
             src={
-              pathname === ""
+              pathname === "" || pathname === "reservation"
                 ? "/sidebar/calendarFocusIcon.png"
                 : "/sidebar/calendarIcon.png"
             }


### PR DESCRIPTION
## ✨ 주요 변경 사항
sidebar에서 예약 캘린더를 선택했을 때 focus 이미지로 바뀔 수 있도록 수정하였습니다

## 🛠 작업 방식
기존에 reservationCalander 페이지가 기본페이지이기 때문에, path==="" 인 경우에만 focus 이미지가 뜨도록 하였습니다. 하지만, 로그인 이후에는 focus이미지가 뜨기 때문에 위의 부분을 path ==="reservation"으로 수정하였습니다 

## 📸 UI 스크린샷
<img width="118" height="274" alt="image" src="https://github.com/user-attachments/assets/3570af5e-80af-4553-90c2-c6b3e7f1a85e" />

## ❗ 기타 참고 사항
