### PR TITLE
fix: 예약창 검색 후 호출 API 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.0.2",
         "sharp": "^0.33.5",
-        "styled-components": "^6.1.13",
+        "styled-components": "^6.1.19",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^11.1.0",
@@ -11874,9 +11874,10 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
-      "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.0.2",
     "sharp": "^0.33.5",
-    "styled-components": "^6.1.13",
+    "styled-components": "^6.1.19",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",

--- a/src/app/components/reservation/reservationModal/ReservationContent.tsx
+++ b/src/app/components/reservation/reservationModal/ReservationContent.tsx
@@ -230,6 +230,7 @@ export default function ReservationContent({
             }
             type="tel"
             onChange={(e) => handleInputChange("phone", e.target.value)}
+            disabled
           />
 
           <div className="flex flex-col">
@@ -244,12 +245,12 @@ export default function ReservationContent({
             <div className="flex flex-row gap-1 w-full">
               <div className="flex-1 font-light bg-[#F6F6F6] border border-[#D1D1D1] p-[8px_12px] rounded-lg text-[#888888] min-h-7 min-w-0 text-sm md:text-base">
                 {mode === "edit" || isSearchSelected
-                  ? userInfo?.endDate?.split("T")[0] || ""
+                  ? userInfo?.planEndDate?.split("T")[0] || ""
                   : ""}
               </div>
               <div className="flex-1 font-light bg-[#F6F6F6] border border-[#D1D1D1] p-[8px_12px] rounded-lg text-[#888888] min-h-7 min-w-0 text-sm md:text-base">
                 {mode === "edit" || isSearchSelected
-                  ? userInfo?.remainingTime || ""
+                  ? userInfo?.remainingTime
                   : ""}
               </div>
             </div>

--- a/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
+++ b/src/app/components/reservation/reservationModal/SelectedEventModal.tsx
@@ -289,7 +289,7 @@ const SelectedEventModal: React.FC<EventProps> = ({
   const handleSelectCustomer = async (customer: any) => {
     if (customer?.customerId) {
       console.log("handleSelectCustomer", customer?.customerId);
-      const customerDetail = await memberAPI?.getCustomerDetail(
+      const customerDetail = await getReservationCustomerDetails(
         customer?.customerId
       );
       setUserInfo((prev: any) => ({
@@ -301,6 +301,8 @@ const SelectedEventModal: React.FC<EventProps> = ({
         planName: customerDetail?.data?.planPayment?.planName,
         memo: customerDetail?.data?.memo,
         progressList: customerDetail?.data?.progressList,
+        planEndDate: customerDetail?.data?.planEndDate,
+        remainingTime: customerDetail?.data?.remainingTime,
       }));
       setSearchKeyword(customer.name);
       setCustomerList([]);

--- a/src/utils/reservation/getReservationCustomerDetails.ts
+++ b/src/utils/reservation/getReservationCustomerDetails.ts
@@ -13,7 +13,7 @@ export default async function getReservationCustomerDetails(
     const data = response.data.data;
 
     if (data) {
-      return {
+      const result = {
         ...data,
         data: {
           ...data,
@@ -22,7 +22,10 @@ export default async function getReservationCustomerDetails(
           mode: "edit",
         },
       };
+      console.log("받아온 예약 고객 상세 데이터:", result);
+      return result;
     }
+    console.log("받아온 예약 고객 상세 데이터 (없음):", response.data);
     return response.data;
   } catch (error: unknown) {
     const errorMessage = errorHandler(error);


### PR DESCRIPTION
## ✨ 주요 변경 사항

SelectedEventModal.tsx 파일에 있는 handleSelectCustomer 함수는 원래 검색 결과에서 선택된 고객 정보를 조회하기 위해 getCustomerDetail API를 호출했습니다. 하지만 해당 API는 회원 리스트 페이지에서 사용하는 API이므로, 기능에 맞게 handleSelectCustomer 함수에서는 getReservationCustomerDetails API를 호출하도록 수정하였습니다.

## 🛠 작업 방식
해당 API를 수정한 후, 수정된 api에 맞추어 setUserInfo에 저장하는 값을 달리하였습니다

## 📸 UI 스크린샷
<img width="1102" height="863" alt="image" src="https://github.com/user-attachments/assets/8c47a748-e8cb-45ff-9f8d-1cf205597659" />

## ❗ 기타 참고 사항
