### PR TITLE
feat: 결제, 미납버튼 ui 수정

### DIFF
--- a/src/app/components/member/detail/PlanPaymentForm.tsx
+++ b/src/app/components/member/detail/PlanPaymentForm.tsx
@@ -20,6 +20,7 @@ const PlanPaymentForm: React.FC<PlanPaymentFormProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isPaid, setIsPaid] = useState(customer.planPayment?.status ?? false);
+
   useEffect(() => {
     setIsPaid(customer.planPayment?.status ?? false);
   }, [customer.planPayment?.status]);
@@ -34,16 +35,13 @@ const PlanPaymentForm: React.FC<PlanPaymentFormProps> = ({
   const { planPayment } = customer;
 
   // ✅ 결제 상태 변경 핸들러
-  const handleToggle = () => {
-    const newStatus = !isPaid;
+  const handleStatusChange = (newStatus: boolean) => {
     setIsPaid(newStatus);
-
     console.log("📌 기존 결제 상태:", planPayment.status);
     console.log("✅ 변경된 결제 상태:", newStatus);
 
-    // ✅ `planPaymentStatus`를 `UpdateCustomerDetail` 타입에 맞게 전달
     onModify({
-      customerId: customer.customerId, // 고객 ID 유지
+      customerId: customer.customerId,
       planPaymentStatus: newStatus,
     });
   };
@@ -61,23 +59,34 @@ const PlanPaymentForm: React.FC<PlanPaymentFormProps> = ({
               {planPayment.planPrice - planPayment.discountPrice}원
             </p>
           </div>
-          {/* 결제토글 */}
-          <div
-            className="flex items-center gap-2 cursor-pointer"
-            onClick={handleToggle}
-          >
-            <FaRegCircleCheck
-              className={`w-5 h-5 ${
-                isPaid ? "text-[#3C6229]" : "text-gray-300"
-              } transition-colors duration-200`}
-            />
-            <span
-              className={`text-sm ${
-                isPaid ? "text-[#3C6229]" : "text-gray-600"
+          {/* 결제 버튼들 */}
+          <div className="flex justify-start gap-2">
+            <button
+              onClick={() => handleStatusChange(false)}
+              className={`flex items-center gap-2 p-2 rounded-md transition-colors duration-200 ${
+                !isPaid ? "text-[#DB5461]" : "text-gray-500"
               }`}
             >
-              {isPaid ? "결제 완료" : "미납"}
-            </span>
+              <FaRegCircleCheck
+                className={`w-5 h-5 ${
+                  !isPaid ? "text-[#DB5461]" : "text-gray-400"
+                }`}
+              />
+              <span className="text-sm font-semibold">미납</span>
+            </button>
+            <button
+              onClick={() => handleStatusChange(true)}
+              className={`flex items-center gap-2 p-2 rounded-md transition-colors duration-200 ${
+                isPaid ? "text-[#3C6229]" : "text-gray-500"
+              }`}
+            >
+              <FaRegCircleCheck
+                className={`w-5 h-5 ${
+                  isPaid ? "text-[#3C6229]" : "text-gray-400"
+                }`}
+              />
+              <span className="text-sm font-semibold">결제 완료</span>
+            </button>
           </div>
         </div>
       }


### PR DESCRIPTION
## ✨ 주요 변경 사항
기존 결제 여부 선택 UI를 변경하였습니다.

이전에는 하나의 버튼으로 모든 UX를 처리하며 토글 형태로 선택을 진행했습니다. 그러나 미납 버튼이 회색으로 표시되어, 사용자가 이를 현재 상태가 미납이 아니라 ‘선택되지 않은 상태’로 오해할 수 있었고, 이로 인해 잘못된 클릭을 유도하는 문제가 있었습니다. 

따라서 이를 개선하기 위해 버튼을 두 개로 분리하고, 선택된 버튼에 색상이 표시되도록 UI를 수정하였습니다.

## 🛠 작업 방식

## 📸 UI 스크린샷
<수정 전>
https://github.com/user-attachments/assets/00b1a14a-a5b4-4d3c-b780-3b14a170266d

<수정 후>
https://github.com/user-attachments/assets/4e58e38d-2d20-4cfb-ac6f-35b963a5030f

## ❗ 기타 참고 사항
