### PR TITLE
fix: 회원 추가, 수정, 삭제 시 skeleton 적용

### DIFF
--- a/src/api/member/index.ts
+++ b/src/api/member/index.ts
@@ -75,23 +75,29 @@ export const memberAPI = {
    * @param data 회원 상세정보 데이터
    * @returns 수정된 회원 데이터
    */
-  updateCustomerDetail: async (data: FormData) => {
-    try {
-      const response = await apiClient.put(
-        "/api/customer/updateCustomer",
-        data,
-        {
-          headers: {
-            "Content-Type": "multipart/form-data",
-          },
-        }
-      );
-      return response.data;
-    } catch (error) {
-      console.error("회원 상세 수정 오류:", error);
-      throw error;
-    }
-  },
+ updateCustomerDetail: async (data: FormData) => {
+  try { 
+    const response = await apiClient.put(
+      "/api/customer/updateCustomer",
+      data,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+
+    // 2초 뒤 새로고침
+    setTimeout(() => {
+      window.location.reload();
+    }, 2000);
+
+    return response.data;
+  } catch (error) {
+    console.error("회원 상세 수정 오류:", error);
+    throw error;
+  }
+},
 
   /**
    * 이용 중인 회원 조회 메서드

--- a/src/app/components/member/create/CreateMember.tsx
+++ b/src/app/components/member/create/CreateMember.tsx
@@ -231,6 +231,7 @@ const CreateMember: React.FC<{
       const response = await memberAPI.registMember(formattedData);
       queryClient.invalidateQueries({ queryKey: ["members", "ACTIVE"] });
       closeModal();
+      window.location.reload();
     } catch (error) {
       console.error("회원 등록 실패:", error);
     }

--- a/src/app/components/member/detail/DetailMember.tsx
+++ b/src/app/components/member/detail/DetailMember.tsx
@@ -86,7 +86,6 @@ const DetailMember: React.FC<DetailMemberProps> = ({ customerId, onClose }) => {
           }))
         : prev?.otherPayment ?? [],
     }));
-
     setIsModified(true);
   };
 
@@ -120,6 +119,7 @@ const DetailMember: React.FC<DetailMemberProps> = ({ customerId, onClose }) => {
         setIsModified(false);
         fetchCustomer(customerId);
         onClose();
+        window.location.reload();
       } catch (error) {
         console.error("❌ 회원 정보 수정 실패:", error);
       }
@@ -132,6 +132,7 @@ const DetailMember: React.FC<DetailMemberProps> = ({ customerId, onClose }) => {
         await updateCustomerStatus(customerId, "DELETED");
         queryClient.invalidateQueries({ queryKey: ["members", "ACTIVE"] });
         onClose();
+        window.location.reload();
       } catch (error) {
         console.error("❌ 회원 삭제 실패:", error);
         alert("회원 삭제 중 오류가 발생했습니다.");


### PR DESCRIPTION
## ✨ 주요 변경 사항

회원 리스트 페이지에서 회원 추가, 수정, 삭제 시 변경 사항이 즉시 반영되지 않고, 사용자가 직접 새로고침을 해야만 최신 회원 정보가 표시되는 문제가 있었습니다.

이를 개선하기 위해, 수정·삭제·추가 이벤트 발생 시 ‘로딩 중’ 상태를 감지하여 스켈레톤 UI를 표시하도록 하여 사용자가 혼란을 겪지 않도록 하였습니다.

## 🛠 작업 방식

handleModify 등 API 호출 함수 내에 window.location.reload()를 추가하여 변경 사항을 즉시 반영하도록 처리했습니다.

## 📸 UI 스크린샷
<추가>

https://github.com/user-attachments/assets/9cf3acd3-fbf4-4082-9737-b684b1047749

<수정>

https://github.com/user-attachments/assets/c1e99cfb-723a-4d88-9b8b-c2b671eb17eb

<삭제>

https://github.com/user-attachments/assets/7e1153b7-a794-46c8-94c9-2dff94a84f97

## ❗ 기타 참고 사항

추후에는 reload() 대신 상태 관리 방식을 통해 더욱 자연스럽게 데이터가 반영될 수 있도록 개선할 예정입니다.
